### PR TITLE
hidden message property change

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -90,7 +90,9 @@
         <!-- See https://checkstyle.org/config_coding.html -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
-        <module name="HiddenField"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+        </module>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MagicNumber"/>


### PR DESCRIPTION
Данный модуль проверяет "Не затеняет ли локальная переменная или параметр поле, определенное в том же классе.",  в  том числе проверяет конструктор. Но данная проверка начинает выскакивать в случаях, когда конструктор генерируется средствами IDE в формате:
```
public SomeClass(String testField) {
   this.testField = testField; // violation, 'testField' param hides 'testField' field
 }
```
Таким образом, если человек генерирует конструктор с помощью IDE. Включение данной проперти будет опасно только для людей которые ручками пишут конструкторы.