### PR TITLE
Add hidden setter field and metamodel suppressions

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -99,6 +99,7 @@
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
             <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
         </module>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -58,6 +58,13 @@
 
         <module name="AbbreviationAsWordInName"/>
         <module name="AbstractClassName"/>
+        
+        <!-- Disable class name and field visibility checks for metamodels -->
+        <module name="SuppressionXpathSingleFilter">
+            <property name="files" value="[A-Z]*_.java"/>
+            <property name="checks" value="AbstractClassName|TypeName|VisibilityModifier"/>
+        </module>
+
         <module name="ClassTypeParameterName">
             <property name="format" value="^[A-Z]*$"/>
         </module>


### PR DESCRIPTION
### Changes: 

1. Allow methods like this (add suppression for setter argument name which name is equal to class field one):
```
private String field;
...
public void setter(String field) {
    this.field = field;
}
```

2. Allow using metamodel classes:

```
@StaticMetamodel(Entity.class)
public abstract class Entity_ {
   ...
}
```